### PR TITLE
[codex] Add app health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,12 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT
       - OTEL_HOSTNAME
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:8080/readyz || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 2m
     deploy:
       resources:
         limits:

--- a/main.go
+++ b/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -17,6 +19,79 @@ const (
 	LIVE ReadingMode = 1 << iota
 	PERIODIC
 )
+
+const (
+	healthServerAddr         = ":8080"
+	liveReadinessTimeout     = time.Minute
+	periodicReadinessTimeout = 15 * time.Minute
+)
+
+type healthState struct {
+	ready          atomic.Bool
+	lastLiveOK     atomic.Int64
+	lastPeriodicOK atomic.Int64
+}
+
+func (h *healthState) markSuccess(mode ReadingMode) {
+	now := time.Now().Unix()
+
+	if mode&LIVE != 0 {
+		h.lastLiveOK.Store(now)
+	}
+	if mode&PERIODIC != 0 {
+		h.lastPeriodicOK.Store(now)
+	}
+
+	h.ready.Store(true)
+}
+
+func (h *healthState) livenessHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func (h *healthState) readinessHandler(w http.ResponseWriter, _ *http.Request) {
+	if !h.ready.Load() {
+		http.Error(w, "not ready", http.StatusServiceUnavailable)
+		return
+	}
+
+	now := time.Now()
+	lastLiveOK := time.Unix(h.lastLiveOK.Load(), 0)
+	lastPeriodicOK := time.Unix(h.lastPeriodicOK.Load(), 0)
+
+	if now.Sub(lastLiveOK) > liveReadinessTimeout {
+		http.Error(w, "live readings stale", http.StatusServiceUnavailable)
+		return
+	}
+	if now.Sub(lastPeriodicOK) > periodicReadinessTimeout {
+		http.Error(w, "periodic readings stale", http.StatusServiceUnavailable)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func startHealthServer(logger *log.Logger, health *healthState) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", health.livenessHandler)
+	mux.HandleFunc("/readyz", health.readinessHandler)
+
+	server := &http.Server{
+		Addr:    healthServerAddr,
+		Handler: mux,
+	}
+
+	go func() {
+		logger.Printf("Health server listening on %s", healthServerAddr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Fatalf("Health server failed: %v", err)
+		}
+	}()
+
+	return server
+}
 
 func getMeterData(reader energy.EnergyDataReader, writers []energy.EnergyDataWriter, mode ReadingMode) error {
 	allReadings := []energy.Reading{}
@@ -73,6 +148,7 @@ func waitForConnection(logger *log.Logger, reader energy.EnergyDataReader, write
 
 func main() {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
+	health := &healthState{}
 
 	// Configure reader
 	geoUsername := os.Getenv("GEO_USERNAME")
@@ -95,8 +171,11 @@ func main() {
 		logger.Println("Skipping OTel; OTEL_EXPORTER_OTLP_ENDPOINT not set")
 	}
 
+	healthServer := startHealthServer(logger, health)
+
 	// Wait for initial connection with retry
 	waitForConnection(logger, reader, writers)
+	health.markSuccess(LIVE | PERIODIC)
 
 	tickLive := time.NewTicker(time.Second * time.Duration(10))
 	tickPeriodic := time.NewTicker(time.Second * time.Duration(300))
@@ -107,10 +186,14 @@ func main() {
 			case <-tickLive.C:
 				if err := getMeterData(reader, writers, LIVE); err != nil {
 					logger.Printf("Error getting live data: %v", err)
+				} else {
+					health.markSuccess(LIVE)
 				}
 			case <-tickPeriodic.C:
 				if err := getMeterData(reader, writers, PERIODIC); err != nil {
 					logger.Printf("Error getting periodic data: %v", err)
+				} else {
+					health.markSuccess(PERIODIC)
 				}
 			}
 		}
@@ -122,6 +205,11 @@ func main() {
 	<-sigs
 
 	logger.Println("Shutting down...")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := healthServer.Shutdown(shutdownCtx); err != nil {
+		logger.Printf("Error shutting down health server: %v", err)
+	}
 	for _, w := range writers {
 		if err := w.Close(); err != nil {
 			logger.Printf("Error closing writer: %v", err)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestReadinessHandlerReturnsUnavailableBeforeInitialSuccess(t *testing.T) {
+	health := &healthState{}
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	health.readinessHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status %d, got %d", http.StatusServiceUnavailable, rec.Code)
+	}
+}
+
+func TestReadinessHandlerReturnsOKAfterRecentSuccess(t *testing.T) {
+	health := &healthState{}
+	health.markSuccess(LIVE | PERIODIC)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	health.readinessHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestReadinessHandlerReturnsUnavailableWhenLiveReadingsAreStale(t *testing.T) {
+	now := time.Now()
+	health := &healthState{}
+	health.ready.Store(true)
+	health.lastLiveOK.Store(now.Add(-liveReadinessTimeout - time.Second).Unix())
+	health.lastPeriodicOK.Store(now.Unix())
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	health.readinessHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status %d, got %d", http.StatusServiceUnavailable, rec.Code)
+	}
+}
+
+func TestReadinessHandlerReturnsUnavailableWhenPeriodicReadingsAreStale(t *testing.T) {
+	now := time.Now()
+	health := &healthState{}
+	health.ready.Store(true)
+	health.lastLiveOK.Store(now.Unix())
+	health.lastPeriodicOK.Store(now.Add(-periodicReadinessTimeout - time.Second).Unix())
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	health.readinessHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status %d, got %d", http.StatusServiceUnavailable, rec.Code)
+	}
+}


### PR DESCRIPTION
This change adds a real application readiness signal for the Dockerized geo-energy collector. Before this branch, the container could only be checked for basic process liveness, which meant Docker would report the service as healthy even if the app had not yet connected successfully to GEO or had stopped producing fresh readings.

The root issue was that the application exposed no probe endpoint, so Compose had no way to distinguish a merely running process from one that was actually ready and functioning. The fix adds lightweight `/healthz` and `/readyz` endpoints in the Go app, tracks the last successful live and periodic meter reads in memory, and updates the Compose healthcheck to call `/readyz` instead of relying on shell-level process checks.

This keeps the container health status aligned with the app's real operating state and gives earlier visibility into stalled or disconnected polling. Validation included `go test ./...` and `docker compose config`.
