### PR TITLE
[codex] Add conductor setup script

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,5 @@
+{
+    "scripts": {
+        "setup": "ln -s \"$CONDUCTOR_ROOT_PATH/.env\" .env"
+    }
+}


### PR DESCRIPTION
This PR adds `conductor.json` with a `setup` script so Conductor workspaces can symlink the repo-local `.env` from `$CONDUCTOR_ROOT_PATH/.env`. Without this config, a fresh Conductor workspace does not automatically expose the expected environment file, which can block local startup and data pipeline testing. The root cause was that the repository had no Conductor-specific bootstrap step even though the app expects `.env` in the workspace root. The fix is a single setup command that creates that symlink during workspace initialization. Validation: `go test ./...`.
